### PR TITLE
Initial support for reading (some) OpenFST binary files.

### DIFF
--- a/src/main/java/com/github/steveash/jopenfst/io/binary/FstBinaryInput.java
+++ b/src/main/java/com/github/steveash/jopenfst/io/binary/FstBinaryInput.java
@@ -1,0 +1,183 @@
+package com.github.steveash.jopenfst.io.binary;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.steveash.jopenfst.MutableFst;
+import com.github.steveash.jopenfst.MutableSymbolTable;
+
+/**
+ * Support for reading binary files produced by OpenFST
+ * 
+ * @author Josh Hansen
+ *
+ */
+public final class FstBinaryInput {
+
+	private FstBinaryInput() {
+		throw new UnsupportedOperationException("Utility class should not be instantiated");
+	}
+
+	private static final Map<String,Class<? extends FstBodyReader>> readers = new HashMap<>();
+	static {
+		readers.put(VectorFstReader.TYPE, VectorFstReader.class.asSubclass(FstBodyReader.class));
+	}
+
+//	public static long bytesRead = 0L;
+
+
+	static int readI32(InputStream in) throws IOException {
+//		bytesRead += 4L;
+
+		final byte[] arr = new byte[4];
+		in.read(arr);
+
+		final ByteBuffer bb = ByteBuffer.wrap(arr);
+		bb.order(ByteOrder.LITTLE_ENDIAN);
+
+		return bb.getInt();
+	}
+
+
+	private static final BigInteger TWO_TO_64 = BigInteger.valueOf(0L);
+	static {
+		TWO_TO_64.flipBit(64);
+	}
+	
+	static BigInteger readU64(InputStream in) throws IOException {
+		final long l = readI64(in);
+
+		final BigInteger messedUpU64 = BigInteger.valueOf(l);
+
+		BigInteger u64;
+		if(messedUpU64.testBit(64)) {// a large u64 is erroneously treated as a negative number
+			u64 = messedUpU64.add(TWO_TO_64);
+		} else {
+			u64 = messedUpU64;
+		}
+
+		return u64;
+
+	}
+
+	static long readI64(InputStream in) throws IOException {
+//		bytesRead += 8L;
+
+		final byte[] arr = new byte[8];
+		in.read(arr);
+
+		final ByteBuffer bb = ByteBuffer.wrap(arr);
+		bb.order(ByteOrder.LITTLE_ENDIAN);
+
+		return bb.getLong();
+	}
+
+	static String readString(InputStream in) throws IOException {
+
+
+		final int length = readI32(in);
+
+//		bytesRead += length;
+
+		final byte[] arr = new byte[length];
+		in.read(arr);
+
+		return new String(arr);
+	}
+
+	public static float readF32(InputStream in) throws IOException {
+//		bytesRead += 4L;
+
+		final byte[] arr = new byte[4];
+		in.read(arr);
+
+		final ByteBuffer bb = ByteBuffer.wrap(arr);
+		bb.order(ByteOrder.LITTLE_ENDIAN);
+
+		return bb.getFloat();
+	}
+
+	public static double readF64(InputStream in) throws IOException {
+//		bytesRead += 8L;
+
+		final byte[] arr = new byte[8];
+		in.read(arr);
+
+		final ByteBuffer bb = ByteBuffer.wrap(arr);
+		bb.order(ByteOrder.LITTLE_ENDIAN);
+
+		return bb.getDouble();
+	}
+
+	/**
+	 * Read an OpenFST binary file and instantiate it as a MutableFst
+	 * 
+	 * @param in An InputStream representing the .fst binary file
+	 * 
+	 * @return The MutableFst representation of the file read.
+	 * 
+	 * @throws IOException
+	 * @throws InstantiationException
+	 * @throws IllegalAccessException
+	 */
+	public static MutableFst readOpenfstBinaryFile(final InputStream in) throws IOException, InstantiationException, IllegalAccessException {
+		// BufferedInputStream gives us mark/reset support, useful for pre-reading the header
+		//		  final InputStream in = new BufferedInputStream(fstIn, FstHeader.HEADER_MAX_BYTES);
+
+		final FstHeader header = FstHeader.read(in);
+
+		final FstBodyReader reader = readers.get(header.type).newInstance();
+		if(reader == null) {
+			throw new IllegalArgumentException(".fst binary file of type '" + header.type + "' is not supported");
+		}
+
+		return reader.read(in, header);
+	}
+
+
+	private static final int SYMBOL_TABLE_MAGIC = 2125658996;
+	public static MutableSymbolTable readSymbolTable(InputStream in) throws IOException {
+
+		final int magic = readI32(in);
+
+		if(magic != SYMBOL_TABLE_MAGIC) {
+			throw new IllegalArgumentException("Attempted to read symbol table, but got magic of " + magic +" where " + SYMBOL_TABLE_MAGIC + " was expected");
+		}
+
+		final MutableSymbolTable syms = new MutableSymbolTable();
+
+		@SuppressWarnings("unused")
+		final String name = readString(in);
+
+		@SuppressWarnings("unused")
+		final long availableKey = readI64(in);
+
+		final long size = readI64(in);
+
+
+//		System.out.println("Reading symbol table " + name + " " + availableKey + " " + size);
+
+		String symbol;
+		long key;
+
+		for(long i = 0; i < size; i++) {
+
+			symbol = readString(in);
+			key = readI64(in);
+
+			syms.put(symbol, (int)key);//FIXME unchecked downcast
+
+			System.out.println(symbol + " -> " + key);
+		}
+
+		return syms;
+	}
+
+
+
+}

--- a/src/main/java/com/github/steveash/jopenfst/io/binary/FstBodyReader.java
+++ b/src/main/java/com/github/steveash/jopenfst/io/binary/FstBodyReader.java
@@ -1,0 +1,27 @@
+package com.github.steveash.jopenfst.io.binary;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.github.steveash.jopenfst.MutableFst;
+
+/**
+ * Interface to support reading various implementations Fst in OpenFST.
+ * 
+ * @author Josh Hansen
+ *
+ */
+public interface FstBodyReader {
+	
+	/**
+	 * Read an FST from an InputStream according to the OpenFST binary format, as per a particular implementation.
+	 * 
+	 * @param in The InputStream representing the .fst file. The stream should be advanced to the byte
+	 *           immediately following the header.
+	 *           
+	 * @param header The header of the .fst file, previously read elsewhere.
+	 * 
+	 * @return A MutableFst instantiating the FST defined by the input
+	 */
+	MutableFst read(InputStream in, FstHeader header) throws IOException;
+}

--- a/src/main/java/com/github/steveash/jopenfst/io/binary/FstHeader.java
+++ b/src/main/java/com/github/steveash/jopenfst/io/binary/FstHeader.java
@@ -1,0 +1,81 @@
+package com.github.steveash.jopenfst.io.binary;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+
+/**
+ * Representation of the header of an OpenFST binary file, with facilities for reading.
+ * 
+ * @author Josh Hansen
+ *
+ */
+public class FstHeader {
+	
+	private static final int OPENFST_MAGIC_NUMBER = 2125659606;
+	
+	private static final int FLAG_INPUT_SYMBOLS = 0x1;
+	private static final int FLAG_OUTPUT_SYMBOLS = 0x2;
+	
+	public final String type;// est 20 bytes
+	public final String arcType;// est 20 bytes
+	public final int version;// 4 bytes
+	public final int flags;// 4 bytes
+	public final BigInteger properties;// 8 bytes
+	public final long start;// 8 bytes
+	public final long numStates;// 8 bytes
+	public final long numArcs;// 8 bytes
+	
+	
+	public FstHeader(String type, String arcType, int version, int flags, BigInteger properties, long start,
+			long numStates, long numArcs) {
+		this.type = type;
+		this.arcType = arcType;
+		this.version = version;
+		this.flags = flags;
+		this.properties = properties;
+		this.start = start;
+		this.numStates = numStates;
+		this.numArcs = numArcs;
+	}
+
+	public static FstHeader read(InputStream in) throws IOException {
+		  
+		  final int magic = FstBinaryInput.readI32(in);// 4 bytes
+		  
+		  if(magic != OPENFST_MAGIC_NUMBER) {
+			  throw new IllegalArgumentException("Provided stream is not an OpenFST binary file");
+		  }
+		  
+		  final String type = FstBinaryInput.readString(in);// est 20 bytes
+		  final String arcType = FstBinaryInput.readString(in);// est 20 bytes
+		  final int version = FstBinaryInput.readI32(in);// 4 bytes
+		  final int flags = FstBinaryInput.readI32(in);// 4 bytes
+		  final BigInteger properties = FstBinaryInput.readU64(in);// 8 bytes
+		  final long start = FstBinaryInput.readI64(in);// 8 bytes
+		  final long numStates = FstBinaryInput.readI64(in);// 8 bytes
+		  final long numArcs = FstBinaryInput.readI64(in);// 8 bytes
+		  
+		  
+		  return new FstHeader(
+				  
+				  type,
+				  arcType,
+				  version,
+				  flags,
+				  properties,
+				  start,
+				  numStates,
+				  numArcs
+				  
+		  );
+	}
+	
+	public boolean hasInputSymbols() {
+		return (flags & FLAG_INPUT_SYMBOLS) > 0;
+	}
+	
+	public boolean hasOutputSymbols() {
+		return (flags & FLAG_OUTPUT_SYMBOLS) > 0;
+	}
+}

--- a/src/main/java/com/github/steveash/jopenfst/io/binary/FstReadOptions.java
+++ b/src/main/java/com/github/steveash/jopenfst/io/binary/FstReadOptions.java
@@ -1,0 +1,15 @@
+package com.github.steveash.jopenfst.io.binary;
+
+import com.github.steveash.jopenfst.SymbolTable;
+
+
+public class FstReadOptions {
+//	public FstHeader header;
+	public SymbolTable inputSymbolsOverride;
+	public SymbolTable outputSymbolsOverride;
+	
+//	public boolean readInputSymbols = true;
+//	
+//	public boolean readOutputSymbols = true;
+	
+}

--- a/src/main/java/com/github/steveash/jopenfst/io/binary/VectorFstReader.java
+++ b/src/main/java/com/github/steveash/jopenfst/io/binary/VectorFstReader.java
@@ -1,0 +1,110 @@
+package com.github.steveash.jopenfst.io.binary;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.github.steveash.jopenfst.MutableFst;
+import com.github.steveash.jopenfst.MutableState;
+
+/**
+ * An FstBodyReader for OpenFST binary files with type "vector".
+ * 
+ * @author Josh Hansen
+ *
+ */
+public class VectorFstReader implements FstBodyReader {
+	
+	public static final String TYPE = "vector";
+	private static final String STANDARD_ARC_TYPE = "standard";
+
+	private static final int NO_STATE = -1;
+	private static final int MIN_VERSION = 2;
+	
+	@Override
+	public MutableFst read(InputStream in, FstHeader header) throws IOException {
+		
+		if(!header.type.equals(TYPE)) {
+			throw new IllegalArgumentException("Attempted to read an FST of type " + TYPE + " but was passed a header with type " + header.type);
+		}
+		
+		if(!header.arcType.equals(STANDARD_ARC_TYPE)) {
+			throw new IllegalArgumentException("Attempted to read an FST with arc type " + header.arcType + " but only " + STANDARD_ARC_TYPE + " is supported");
+		}
+		
+		if(header.version < MIN_VERSION) {
+			throw new IllegalArgumentException("Reading an FST of type '" + TYPE + "' requires minimum version of " + MIN_VERSION + " but version " + header.version + " was found");
+		}
+		
+		/*
+		 * FIXME downcast necessitated by MutableFst(int) constructor
+		 *       and ultimately Java array addressing via ArrayList
+		 *       
+		 *       This can apparently be done in a checked fashion in Java 8, fwiw
+		 *       https://stackoverflow.com/questions/1590831/safely-casting-long-to-int-in-java
+		 */
+		MutableFst fst;
+		if(header.numStates == NO_STATE) {
+			fst = new MutableFst();
+		} else {
+			fst = new MutableFst((int)header.numStates);
+		}
+		
+		
+		
+		if(header.hasInputSymbols()) {
+			fst.setInputSymbolsAsCopy(FstBinaryInput.readSymbolTable(in));
+		}
+		
+		if(header.hasOutputSymbols()) {
+			fst.setOutputSymbolsAsCopy(FstBinaryInput.readSymbolTable(in));
+		}
+		
+		final MutableState startState = new MutableState();
+		fst.addState(startState);
+		fst.setStart(startState);
+		
+		int stateIdx;
+		
+		// Pre-instantiate states
+		for(stateIdx = 0; header.numStates == NO_STATE || stateIdx < header.numStates; stateIdx++) {
+			fst.addState(new MutableState());
+		}
+		
+		
+		for(stateIdx = 0; header.numStates == NO_STATE || stateIdx < header.numStates; stateIdx++) {
+			final MutableState state = fst.getState(stateIdx);
+			
+			float weight = FstBinaryInput.readF32(in);//???
+			
+			state.setFinalWeight(weight);
+			
+			final long arcCount = FstBinaryInput.readI64(in);
+			
+//			System.out.println("State " + stateIdx + " weight " + weight + " arc count " + arcCount);
+			
+			for(long arcIdx = 0; arcIdx < arcCount; arcIdx++) {
+				
+				//NOTE These types correspond to the StdArc in OpenFST. Could be generalized later.
+				
+				final int inputLabelIdx = FstBinaryInput.readI32(in);
+				final int outputLabelIdx = FstBinaryInput.readI32(in);
+				final float arcWeight = FstBinaryInput.readF32(in);
+				final int nextStateIdx = FstBinaryInput.readI32(in);
+				
+				final MutableState nextState = fst.getState(nextStateIdx);
+				fst.addArc(state, inputLabelIdx, outputLabelIdx, nextState, arcWeight);
+				
+			}
+			
+		}
+		
+		if(header.numStates != NO_STATE && stateIdx != header.numStates) {
+			throw new IllegalArgumentException("Expected " + header.numStates +" states in input; found " + stateIdx);
+		}
+		
+		
+		return fst;
+		
+	}
+
+}


### PR DESCRIPTION
Some code to allow reading of some OpenFST binary files.

At present it doesn't support anything close to all the possible variations of OpenFST's types, but it will get you the equivalent of VectorFst<StdArc>, I think.

Almost certainly there are bugs. I've only tested it on some .fst files that Phonetisaurus generates.