### PR TITLE
Backport from Java 8 to Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>com.github.steveash.jopenfst</groupId>
   <artifactId>jopenfst</artifactId>
   <name>jopenfst</name>
-  <version>0.3.0</version>
+  <version>0.3.0-java7</version>
   <description>Partial Java port of the OpenFST library; forked from the CMU Sphinx project</description>
   <packaging>jar</packaging>
 
@@ -124,8 +124,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/github/steveash/jopenfst/semiring/GallicSemiring.java
+++ b/src/main/java/com/github/steveash/jopenfst/semiring/GallicSemiring.java
@@ -18,6 +18,7 @@ package com.github.steveash.jopenfst.semiring;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.github.steveash.jopenfst.semiring.GallicSemiring.GallicWeight;
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Ordering;
 import com.google.common.math.DoubleMath;
@@ -36,7 +37,7 @@ import static com.github.steveash.jopenfst.semiring.GallicSemiring.GallicMode.RE
  * Gallic weights are useful for representing FSTs _as_ FSAs; we convert the output labels + edge weights into a
  * single Gallic weight and then (within the constraints of the gallic semiring) it is a normal FSA
  */
-public class GallicSemiring implements GenericSemiring<GallicWeight> {
+public class GallicSemiring extends GenericSemiring<GallicWeight> {
 
   public enum GallicMode {
 
@@ -75,7 +76,13 @@ public class GallicSemiring implements GenericSemiring<GallicWeight> {
    * primitive weight (to break shortlex ties)
    */
   public static final Ordering<GallicWeight> NATURAL_ORDERING = SHORTLEX_ORDERING.compound(
-    Ordering.natural().onResultOf(GallicWeight::getWeight)
+		  Ordering.natural().onResultOf(new Function<GallicWeight,Double>(){
+				@Override
+				public Double apply(GallicWeight arg0) {
+					return Double.valueOf( arg0.getWeight() );
+				}
+			}
+		  )
   );
 
   private final GallicWeight zero;

--- a/src/main/java/com/github/steveash/jopenfst/semiring/GenericSemiring.java
+++ b/src/main/java/com/github/steveash/jopenfst/semiring/GenericSemiring.java
@@ -23,7 +23,7 @@ package com.github.steveash.jopenfst.semiring;
  * Given the performance sensitive nature of most of the Semiring operations you wouldn't want to use
  * GenericSemiring<Double> (and get lots of boxing) where you could use Semiring instead
  */
-public interface GenericSemiring<W> {
+public abstract class GenericSemiring<W> {
 
   /**
    * returns a plus b for this semiring; plus is the generalization of combining sequences
@@ -32,7 +32,7 @@ public interface GenericSemiring<W> {
    * @param b weight W
    * @return resulting weight W
    */
-  W plus(W a, W b);
+  public abstract W plus(W a, W b);
 
   /**
    * returns the reverse of the weight for this semiring
@@ -40,7 +40,7 @@ public interface GenericSemiring<W> {
    * @param a
    * @return
    */
-  W reverse(W a);
+  public abstract W reverse(W a);
 
   /**
    * returns a times b for this semiring; times is the generalization of extending a sequence (like a path)
@@ -49,7 +49,7 @@ public interface GenericSemiring<W> {
    * @param b
    * @return
    */
-  W times(W a, W b);
+  public abstract W times(W a, W b);
 
   /**
    * returns a dividedBy b; divide is only defined on some semirings and means: c = a times b then c dividedB b = a
@@ -58,21 +58,21 @@ public interface GenericSemiring<W> {
    * @param b
    * @return
    */
-  W divide(W a, W b);
+  public abstract W divide(W a, W b);
 
   /**
    * The ZERO element for this semiring; requirement that x = plus(x, zero)
    *
    * @return
    */
-  W zero();
+  public abstract W zero();
 
   /**
    * The ONE element for this semiring; requirement that x = times(x, one)
    *
    * @return
    */
-  W one();
+  public abstract W one();
 
   /**
    * Returns true if a is a member of this semiring
@@ -80,7 +80,7 @@ public interface GenericSemiring<W> {
    * @param a
    * @return true if member, false if not
    */
-  boolean isMember(W a);
+  public abstract boolean isMember(W a);
 
   /**
    * Returns true if these two weights, members of this semiring, are approx equal to each other
@@ -88,21 +88,21 @@ public interface GenericSemiring<W> {
    * @param b
    * @return
    */
-  boolean isApproxEqual(W a, W b);
+  public abstract boolean isApproxEqual(W a, W b);
 
   /**
    * Returns true is the given weight is the zero element in this semiring
    * @param a
    * @return
    */
-  boolean isZero(W a);
+  public abstract boolean isZero(W a);
 
   /**
    * Returns true if the given weight is NOT the zero element in this semiring
    * @param a
    * @return
    */
-  default boolean isNotZero(W a) {
+  public boolean isNotZero(W a) {
     return !isZero(a);
   }
 
@@ -114,7 +114,7 @@ public interface GenericSemiring<W> {
    * @param b
    * @return
    */
-  default W commonDivisor(W a, W b) {
+  public W commonDivisor(W a, W b) {
     throw new UnsupportedOperationException("semiring " + this + " doesnt support common divisor");
   }
 
@@ -132,7 +132,7 @@ public interface GenericSemiring<W> {
    *
    * We define the strict version of this order below.
    */
-  default boolean naturalLess(W a, W b) {
+  public boolean naturalLess(W a, W b) {
     return (!isApproxEqual(a, b) && isApproxEqual(plus(a, b), a));
   }
 }

--- a/src/main/java/com/github/steveash/jopenfst/semiring/PrimitiveSemiringAdapter.java
+++ b/src/main/java/com/github/steveash/jopenfst/semiring/PrimitiveSemiringAdapter.java
@@ -23,7 +23,7 @@ import com.google.common.math.DoubleMath;
  * Adapter between a primitive simiring and a generic semiring; useful for testing and non-performance sensitive
  * areas
  */
-public class PrimitiveSemiringAdapter implements GenericSemiring<Double> {
+public class PrimitiveSemiringAdapter extends GenericSemiring<Double> {
 
   private final Semiring semiring;
 

--- a/src/main/java/com/github/steveash/jopenfst/semiring/UnionSemiring.java
+++ b/src/main/java/com/github/steveash/jopenfst/semiring/UnionSemiring.java
@@ -44,7 +44,7 @@ import java.util.Objects;
  * @param <W> the type of the weight contained in a unionweight
  * @param <S> the type of the semiring that governs the contained W weight type
  */
-public class UnionSemiring<W, S extends GenericSemiring<W>> implements GenericSemiring<UnionWeight<W>> {
+public class UnionSemiring<W, S extends GenericSemiring<W>> extends GenericSemiring<UnionWeight<W>> {
 
   public enum UnionMode {
     // (default) this is the typical semantics of union described in the class doc
@@ -67,7 +67,11 @@ public class UnionSemiring<W, S extends GenericSemiring<W>> implements GenericSe
    */
   public static <W extends Comparable<W>, S extends GenericSemiring<W>> UnionSemiring<W, S> makeForNaturalOrdering(
     S weightSemiring) {
-    return makeForOrdering(weightSemiring, Ordering.natural(), defaultMerge());
+	  
+	final Ordering<W> ordering = Ordering.natural();
+	final MergeStrategy<W> merge = defaultMerge();
+	  
+    return makeForOrdering(weightSemiring, ordering, merge);//FIXME
   }
 
   /**
@@ -330,7 +334,12 @@ public class UnionSemiring<W, S extends GenericSemiring<W>> implements GenericSe
   /**
    * Default merge just picks one arbitrarily (but it always picks the left one)
    */
-  private static final MergeStrategy<?> DEFAULT_MERGE = (MergeStrategy<Object>) (a, b) -> a;
+  private static final MergeStrategy<?> DEFAULT_MERGE = new MergeStrategy<Object>() {
+		@Override
+		public Object merge(Object a, Object b) {
+			return a;
+		}
+  };
 
   public static <W> MergeStrategy<W> defaultMerge() {
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/github/steveash/jopenfst/WeightGenerator.java
+++ b/src/test/java/com/github/steveash/jopenfst/WeightGenerator.java
@@ -61,7 +61,7 @@ public abstract class WeightGenerator<W> {
     };
   }
 
-  public static WeightGenerator<UnionWeight<Double>> makeUnion(int seed, boolean onlySingles) {
+  public static WeightGenerator<UnionWeight<Double>> makeUnion(int seed, final boolean onlySingles) {
     return new WeightGenerator<UnionWeight<Double>>(seed) {
       @Override
       public UnionWeight<Double> generate() {

--- a/src/test/java/com/github/steveash/jopenfst/semiring/SemiringTester.java
+++ b/src/test/java/com/github/steveash/jopenfst/semiring/SemiringTester.java
@@ -70,51 +70,117 @@ public class SemiringTester<W> {
     this.randValuesToTest = randValuesToTest;
   }
 
-  private void assertSemiringPropertiesOnValues(GenericSemiring<W> s, W a, W b, W c) {
+  private void assertSemiringPropertiesOnValues(final GenericSemiring<W> s, W a, W b, W c) {
 
     // closure
-    assertTwo(a, b, (aa, bb) -> s.isMember(s.plus(aa, bb)));
-    assertTwo(a, b, (aa, bb) -> s.isMember(s.times(aa, bb)));
+    assertTwo(a, b, new BiFunction<W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb) {
+			return s.isMember(s.plus(aa, bb));
+		}
+	});
+    
+    assertTwo(a, b, new BiFunction<W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb) {
+			return s.isMember(s.times(aa, bb));
+		}
+	});
+    
+    
     // associativeity
-    assertThree(a, b, c, (aa, bb, cc) ->
-      s.isApproxEqual(s.plus(aa, s.plus(bb, cc)),
-        s.plus(s.plus(aa, bb), cc))
-    );
-    assertThree(a, b, c, (aa, bb, cc) ->
-      s.isApproxEqual(s.times(aa, s.times(bb, cc)),
-        s.times(s.times(aa, bb), cc))
-    );
+    assertThree(a, b, c, new TriFunction<W,W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb, W cc) {
+			return s.isApproxEqual(s.plus(aa, s.plus(bb, cc)),
+			        s.plus(s.plus(aa, bb), cc));
+		}
+	});
+    assertThree(a, b, c, new TriFunction<W,W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb, W cc) {
+			return s.isApproxEqual(s.times(aa, s.times(bb, cc)),
+			        s.times(s.times(aa, bb), cc));
+		}
+	});
     // identity operations
-    assertTwo(a, b, (aa, bb) -> s.isApproxEqual(aa, s.plus(aa, s.zero())));
-    assertTwo(a, b, (aa, bb) -> s.isApproxEqual(aa, s.plus(s.zero(), aa)));
-    assertTwo(a, b, (aa, bb) -> s.isApproxEqual(aa, s.times(aa, s.one())));
-    assertTwo(a, b, (aa, bb) -> s.isApproxEqual(aa, s.times(s.one(), aa)));
+    assertTwo(a, b, new BiFunction<W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb) {
+			return s.isApproxEqual(aa, s.plus(aa, s.zero()));
+		}
+	});
+    
+    
+    assertTwo(a, b, new BiFunction<W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb) {
+			return s.isApproxEqual(aa, s.plus(s.zero(), aa));
+		}
+	});
+    assertTwo(a, b, new BiFunction<W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb) {
+			return s.isApproxEqual(aa, s.times(aa, s.one()));
+		}
+	});
+    assertTwo(a, b, new BiFunction<W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb) {
+			return s.isApproxEqual(aa, s.times(s.one(), aa));
+		}
+	});
     // commutative
-    assertTwo(a, b, (aa, bb) -> s.isApproxEqual(s.plus(aa, bb), s.plus(bb, aa)));
+    assertTwo(a, b, new BiFunction<W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb) {
+			return s.isApproxEqual(s.plus(aa, bb), s.plus(bb, aa));
+		}
+	});
     // multiplication isn't always defined to be commutative but i think in the semirings i have so far it should be
-    assertTwo(a, b, (aa, bb) -> s.isApproxEqual(s.times(aa, bb), s.times(bb, aa)));
+    assertTwo(a, b, new BiFunction<W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb) {
+			return s.isApproxEqual(s.times(aa, bb), s.times(bb, aa));
+		}
+	});
     // zero is the annihilator
-    assertTwo(a, b, (aa, bb) -> s.isApproxEqual(s.zero(), s.times(aa, s.zero())));
-    assertTwo(a, b, (aa, bb) -> s.isApproxEqual(s.zero(), s.times(s.zero(), aa)));
+    assertTwo(a, b, new BiFunction<W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb) {
+			return s.isApproxEqual(s.zero(), s.times(aa, s.zero()));
+		}
+	});
+    assertTwo(a, b, new BiFunction<W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb) {
+			return s.isApproxEqual(s.zero(), s.times(s.zero(), aa));
+		}
+	});
     // left commutative (i think all of the rings that i have are this, but there are some rings that aren't
     // (e.g. right string ring), so this might need to be generalized in the future like openfst is
-    assertThree(a, b, c, (aa, bb, cc) ->
-      s.isApproxEqual(s.times(aa, s.plus(bb, cc)),
-        s.plus(s.times(aa, bb), s.times(aa, cc)))
-    );
+    assertThree(a, b, c, new TriFunction<W,W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb, W cc) {
+			return s.isApproxEqual(s.times(aa, s.times(bb, cc)),
+			        s.times(s.times(aa, bb), cc));
+		}
+	});
   }
 
-  private void assertDivideOnValues(GenericSemiring<W> s, W a, W b) {
+  private void assertDivideOnValues(final GenericSemiring<W> s, W a, W b) {
     // test left division
     W ab = s.times(a, b);
-    assertThree(a, b, ab, (aa, bb, aabb) -> {
-        W dd = s.divide(aabb, aa);
-        if (!s.isMember(dd)) { // division is defined to work on the entire range of values or all semirings
-          return true;
-        }
-        return s.isApproxEqual(aabb, s.times(aa, dd));
-      }
-    );
+    assertThree(a, b, ab, new TriFunction<W,W,W,Boolean>(){
+		@Override
+		public Boolean apply(W aa, W bb, W aabb) {
+	        W dd = s.divide(aabb, aa);
+	        if (!s.isMember(dd)) { // division is defined to work on the entire range of values or all semirings
+	          return true;
+	        }
+	        return s.isApproxEqual(aabb, s.times(aa, dd));
+		}
+	});
   }
 
   private <T, U> void assertTwo(T first, U second, BiFunction<T, U, Boolean> func) {

--- a/src/test/java/com/github/steveash/jopenfst/semiring/UnionSemiringTest.java
+++ b/src/test/java/com/github/steveash/jopenfst/semiring/UnionSemiringTest.java
@@ -42,10 +42,15 @@ public class UnionSemiringTest {
     weightRing = TropicalSemiring.INSTANCE;
     gallicRing = new GallicSemiring(weightRing, GallicSemiring.GallicMode.RESTRICT_GALLIC);
     ring = UnionSemiring.makeForNaturalOrdering(new PrimitiveSemiringAdapter(TropicalSemiring.INSTANCE));
-    UnionSemiring.MergeStrategy<GallicWeight> merge = (a, b) -> {
-      Preconditions.checkArgument(a.getLabels().equals(b.getLabels()), "cant merge different labels");
-      return GallicWeight.create(a.getLabels(), weightRing.plus(a.getWeight(), b.getWeight()));
-    };
+    
+    UnionSemiring.MergeStrategy<GallicWeight> merge = new UnionSemiring.MergeStrategy<GallicWeight>() {
+		@Override
+		public GallicWeight merge(GallicWeight a, GallicWeight b) {
+		      Preconditions.checkArgument(a.getLabels().equals(b.getLabels()), "cant merge different labels");
+		      return GallicWeight.create(a.getLabels(), weightRing.plus(a.getWeight(), b.getWeight()));
+		}
+	};
+    
     gallicUnionRing = UnionSemiring.makeForOrdering(gallicRing, GallicSemiring.SHORTLEX_ORDERING, merge);
     zero = gallicUnionRing.zero();
   }


### PR DESCRIPTION
Replace the small amounts of Java 8 code with Java 7 constructs in order to better support older platforms.